### PR TITLE
fix: rebuild previews even when there are no changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ async function main() {
           },
       branch,
       commit_message: commitMessage,
+      allow_empty: true,
     });
     let buildId = build.id;
     let languages = Object.keys(build.targets) as Array<


### PR DESCRIPTION
I ran into an error where it failed to generate a Stainless build because there were no changes.

Error:

```
Using parent build: bui_0cmabtvzxq000020s6hizu6sco
Previous build against branch found: bui_0cmabtvzxq000020s6hizu6sco
Branch already up to date
Error interacting with API: BadRequestError: 400 No changes to commit
    at APIError.generate (/home/runner/work/_actions/stainless-api/build-sdk-action/9c39a4ae05e7[46](https://github.com/scorecard-ai/scorecard/actions/runs/14850023070/job/41691758952?pr=2209#step:6:47)6ca7c257bb28a278df72e1369e/dist/index.js:28369:20)
    at StainlessV0.makeStatusError (/home/runner/work/_actions/stainless-api/build-sdk-action/9c39a4ae05e7466ca7c257bb28a278df72e1369e/dist/index.js:27895:32)
    at StainlessV0.makeRequest (/home/runner/work/_actions/stainless-api/build-sdk-action/9c39a4ae05e7466ca7c257bb28a278df72e1369e/dist/index.js:28033:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (/home/runner/work/_actions/stainless-api/build-sdk-action/9c39a4ae05e7466ca7c257bb28a278df72e1369e/dist/index.js:25809:23) {
  status: 400,
  headers: Headers {
    'access-control-allow-credentials': 'true',
    'content-type': 'application/json',
    etag: '"a2bdcd8621f9b2042396f25826ada286c0[49](https://github.com/scorecard-ai/scorecard/actions/runs/14850023070/job/41691758952?pr=2209#step:6:50)0201"',
    vary: 'Origin, Accept-Encoding',
    'content-encoding': 'gzip',
    'x-cloud-trace-context': '3d404657f9c591b8a3be687baaf60438',
    date: 'Tue, 06 May 2025 01:54:32 GMT',
    server: 'Google Frontend',
    via: '1.1 google',
    'x-frame-options': 'SAMEORIGIN',
    'referrer-policy': 'strict-origin-when-cross-origin',
    'x-content-type-options': 'nosniff',
    'strict-transport-security': 'max-age=63072000; includeSubDomains',
    'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000',
    'transfer-encoding': 'chunked'
  },
  error: { error: 'bad request', message: 'No changes to commit' }
```

I haven't tested it, but I'm guessing this will fix it?