### PR TITLE
give `guess_config` a default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ inputs:
       If true, update the existing Stainless config file based on the OpenAPI
       spec. Cannot be specified if `config_path` is specified.
     required: false
+    default: false
   branch:
     description: Stainless branch to create the build on.
     required: false


### PR DESCRIPTION
A bit confusing that this is necessary since we do
```
const guessConfig = getBooleanInput("guess_config", { required: false });
```
in our code, but apparently that doesn't work the way we expected it to.